### PR TITLE
cmake: fix webpmux lib name for cmake linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,19 +471,18 @@ endif()
 
 if(WEBP_BUILD_LIBWEBPMUX)
   parse_makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/mux "WEBP_MUX_SRCS" "")
-  add_library(libwebpmux ${WEBP_MUX_SRCS})
-  target_link_libraries(libwebpmux webp)
-  target_include_directories(libwebpmux
+  add_library(webpmux ${WEBP_MUX_SRCS})
+  target_link_libraries(webpmux webp)
+  target_include_directories(webpmux
                              PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                      ${CMAKE_CURRENT_SOURCE_DIR})
-  set_version(mux/Makefile.am libwebpmux webpmux)
-  set_target_properties(libwebpmux
+  set_version(mux/Makefile.am webpmux webpmux)
+  set_target_properties(webpmux
                         PROPERTIES PUBLIC_HEADER
                                    "${CMAKE_CURRENT_SOURCE_DIR}/src/webp/mux.h;\
 ${CMAKE_CURRENT_SOURCE_DIR}/src/webp/mux_types.h;\
 ${CMAKE_CURRENT_SOURCE_DIR}/src/webp/types.h;")
-  set_target_properties(libwebpmux PROPERTIES OUTPUT_NAME webpmux)
-  list(APPEND INSTALLED_LIBRARIES libwebpmux)
+  list(APPEND INSTALLED_LIBRARIES webpmux)
   configure_pkg_config("src/mux/libwebpmux.pc")
 endif()
 
@@ -497,7 +496,7 @@ if(WEBP_BUILD_GIF2WEBP)
                         exampleutil
                         imageioutil
                         webp
-                        libwebpmux
+                        webpmux
                         ${WEBP_DEP_GIF_LIBRARIES})
   target_include_directories(gif2webp PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
   install(TARGETS gif2webp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -514,7 +513,7 @@ if(WEBP_BUILD_IMG2WEBP)
                         imagedec
                         imageioutil
                         webp
-                        libwebpmux)
+                        webpmux)
   target_include_directories(img2webp PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
   install(TARGETS img2webp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
@@ -563,7 +562,7 @@ if(WEBP_BUILD_WEBPMUX)
   parse_makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/examples "WEBPMUX_SRCS"
                     "webpmux")
   add_executable(webpmux ${WEBPMUX_SRCS})
-  target_link_libraries(webpmux exampleutil imageioutil libwebpmux webp)
+  target_link_libraries(webpmux exampleutil imageioutil webpmux webp)
   target_include_directories(webpmux PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
   install(TARGETS webpmux RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()


### PR DESCRIPTION
When using CMake the `<prefix>/usr/share/WebP/cmake/WebPConfig.cmake` gets
used to get the names of the libraries to link against.

Since version 1.2.1 of libwebp, libwebpmux is on by default.
This causes a linker error because the linker arg should be `-lwebpmux`
instead of `-llibwebpmux`.

This is fixable by renaming `libwebpmux` to `webpmux` in a few places.

This was identified after an update to 1.2.1 of libwebp in the OpenWrt
project:
  https://github.com/openwrt/packages/pull/16766

Internally in OpenWrt, this was patched here:
  https://github.com/openwrt/packages/pull/16784

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>