### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -96,6 +96,18 @@ make
 make install
 ```
 
+## Building libwebp - Using vcpkg
+
+You can download and install libwebp using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libwebp
+
+The libwebp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## CMake
 
 With CMake, you can compile libwebp, cwebp, dwebp, gif2webp, img2webp, webpinfo


### PR DESCRIPTION
libwebp is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for libwebp and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libwebp, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libwebp/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)