### PR TITLE
added: cached config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,16 @@ if(NOT CMAKE_BUILD_TYPE)
             FORCE)
 endif()
 
-# Include dependencies.
-include(cmake/deps.cmake)
-include(GNUInstallDirs)
+set(WEBP_CONFIG_GEN ON)
+if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/src/webp/config.h)
+ set(WEBP_CONFIG_GEN OFF)
+endif()
+
+if (WEBP_CONFIG_GEN)
+  # Include dependencies.
+  include(cmake/deps.cmake)
+  include(GNUInstallDirs)
+endif()
 
 if(BUILD_SHARED_LIBS AND NOT DEFINED CMAKE_INSTALL_RPATH)
   # Set the rpath to match autoconf/libtool behavior. Note this must be set
@@ -229,9 +236,11 @@ foreach(FILE ${WEBP_SIMD_FILES_NOT_TO_INCLUDE})
   list(REMOVE_ITEM WEBP_DSP_DEC_SRCS ${FILE})
 endforeach()
 
-# Generate the config.h file.
-configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/src/webp/config.h @ONLY)
+if (WEBP_CONFIG_GEN)
+  # Generate the config.h file.
+  configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/config.h.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/src/webp/config.h @ONLY)
+endif()
 add_definitions(-DHAVE_CONFIG_H)
 
 # Set the version numbers.


### PR DESCRIPTION
This pull request introduces caching for the config.h file, optimizing the build process by avoiding redundant checks for previously performed operations.
Changes Made

    Added caching for config.h by utilizing a cached flag (WEBP_CONFIG_GEN).
    The new code checks if the config.h file already exists in the ${CMAKE_CURRENT_BINARY_DIR}/src/webp/ directory and sets the WEBP_CONFIG_GEN flag accordingly.
    If WEBP_CONFIG_GEN is true, the dependencies are included, such as cmake/deps.cmake and GNUInstallDirs.
    The config.h file is generated only if WEBP_CONFIG_GEN is true, using the config.h.in template and saving the output to ${CMAKE_CURRENT_BINARY_DIR}/src/webp/config.h.
    The -DHAVE_CONFIG_H definition is added using add_definitions to indicate that the configuration file is available.

Purpose

The purpose of this change is to eliminate unnecessary checks for operations that have already been performed during the initial generation of the target platform. By caching the config.h file, subsequent builds can skip these steps, resulting in faster and more efficient builds.
Additional Notes

The previous build process involved detecting the C compiler ABI info, compile features, checking for library dependencies, and performing tests for various flags and include files. These steps are crucial for configuring the build correctly, but once they have been executed, they can be safely skipped in subsequent builds by relying on the cached config.h file.

Please review the changes and consider merging this pull request if you find it suitable. It will contribute to improved build times and more streamlined development processes.

Thank you for your attention to this matter.

Best regards,
Sergei