### PR TITLE
Fix C11 Undefined Behavior in AppendToMemBuffer offset calculation

### DIFF
--- a/src/dec/idec_dec.c
+++ b/src/dec/idec_dec.c
@@ -203,6 +203,8 @@ WEBP_NODISCARD static int AppendToMemBuffer(WebPIDecoder* const idec,
     return 0;
   }
 
+    ptrdiff_t safe_offset = 0;
+
   if (mem->end + data_size > mem->buf_size) {  // Need some free memory
     const size_t new_mem_start = old_start - old_base;
     const size_t current_size = MemDataSize(mem) + new_mem_start;
@@ -211,6 +213,11 @@ WEBP_NODISCARD static int AppendToMemBuffer(WebPIDecoder* const idec,
     uint8_t* const new_buf =
         (uint8_t*)WebPSafeMalloc(extra_size, sizeof(*new_buf));
     if (new_buf == NULL) return 0;
+    
+    if (old_start != NULL) {
+      safe_offset = (ptrdiff_t)((uintptr_t)(new_buf + new_mem_start) - (uintptr_t)old_start);
+    }
+    
     if (old_base != NULL) WEBP_UNSAFE_MEMCPY(new_buf, old_base, current_size);
     WebPSafeFree(mem->buf);
     mem->buf = new_buf;
@@ -224,7 +231,7 @@ WEBP_NODISCARD static int AppendToMemBuffer(WebPIDecoder* const idec,
   mem->end += data_size;
   assert(mem->end <= mem->buf_size);
 
-  DoRemap(idec, mem->buf + mem->start - old_start);
+  DoRemap(idec, safe_offset);
   return 1;
 }
 

--- a/tests/fuzzer/idec_ub_fuzzer.cc
+++ b/tests/fuzzer/idec_ub_fuzzer.cc
@@ -1,0 +1,34 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "src/webp/decode.h"
+
+// OSS-Fuzz entrypoint
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (size < 1) return 0;
+
+    WebPIDecoder* idec = WebPINewDecoder(NULL);
+    if (!idec) return 0;
+    
+    size_t chunk_size = 1;
+    size_t offset = 0;
+    
+    while (offset < size) {
+        size_t current_chunk = size - offset;
+        if (current_chunk > chunk_size) {
+            current_chunk = chunk_size;
+        }
+        
+        VP8StatusCode status = WebPIAppend(idec, data + offset, current_chunk);
+        
+        if (status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED) {
+            break; 
+        }
+        
+        offset += current_chunk;
+        chunk_size = (chunk_size * 2) + 1;
+    }
+
+    WebPIDelete(idec);
+    return 0; 
+}


### PR DESCRIPTION
Added safe uintptr_t conversion to avoid disjoint pointer anomalies during aggressive heap reallocation.