### PR TITLE
dsp/lossless: add -fbounds-safety annotations to predictor functions

### DIFF
--- a/src/dsp/lossless.c
+++ b/src/dsp/lossless.c
@@ -23,6 +23,7 @@
 #include "src/dsp/cpu.h"
 #include "src/dsp/dsp.h"
 #include "src/dsp/lossless_common.h"
+#include "src/utils/bounds_safety.h"
 #include "src/utils/endian_inl_utils.h"
 #include "src/utils/utils.h"
 #include "src/webp/decode.h"
@@ -111,90 +112,101 @@ static WEBP_INLINE uint32_t Select(uint32_t a, uint32_t b, uint32_t c) {
 //------------------------------------------------------------------------------
 // Predictors
 
-static uint32_t VP8LPredictor0_C(const uint32_t* const left,
-                                 const uint32_t* const top) {
+// Note: 'left' is always accessed as a single element (*left); 'top' is
+// accessed with negative offsets (top[-1]) in several predictors, hence it
+// requires WEBP_BIDI_INDEXABLE. The caller guarantees that top[-1] and top[1]
+// are within bounds (i.e. this is never called on the first pixel of a row).
+static uint32_t VP8LPredictor0_C(const uint32_t* WEBP_SINGLE const left,
+                                 const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   (void)top;
   (void)left;
   return ARGB_BLACK;
 }
-static uint32_t VP8LPredictor1_C(const uint32_t* const left,
-                                 const uint32_t* const top) {
+static uint32_t VP8LPredictor1_C(const uint32_t* WEBP_SINGLE const left,
+                                 const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   (void)top;
   return *left;
 }
-uint32_t VP8LPredictor2_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor2_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   (void)left;
   return top[0];
 }
-uint32_t VP8LPredictor3_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor3_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   (void)left;
   return top[1];
 }
-uint32_t VP8LPredictor4_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor4_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   (void)left;
-  return top[-1];
+  return top[-1];  // Requires WEBP_BIDI_INDEXABLE: backward access at top[-1]
 }
-uint32_t VP8LPredictor5_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor5_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   const uint32_t pred = Average3(*left, top[0], top[1]);
   return pred;
 }
-uint32_t VP8LPredictor6_C(const uint32_t* const left,
-                          const uint32_t* const top) {
-  const uint32_t pred = Average2(*left, top[-1]);
+uint32_t VP8LPredictor6_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
+  const uint32_t pred = Average2(*left, top[-1]);  // backward access
   return pred;
 }
-uint32_t VP8LPredictor7_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor7_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   const uint32_t pred = Average2(*left, top[0]);
   return pred;
 }
-uint32_t VP8LPredictor8_C(const uint32_t* const left,
-                          const uint32_t* const top) {
-  const uint32_t pred = Average2(top[-1], top[0]);
+uint32_t VP8LPredictor8_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
+  const uint32_t pred = Average2(top[-1], top[0]);  // backward access
   (void)left;
   return pred;
 }
-uint32_t VP8LPredictor9_C(const uint32_t* const left,
-                          const uint32_t* const top) {
+uint32_t VP8LPredictor9_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   const uint32_t pred = Average2(top[0], top[1]);
   (void)left;
   return pred;
 }
-uint32_t VP8LPredictor10_C(const uint32_t* const left,
-                           const uint32_t* const top) {
-  const uint32_t pred = Average4(*left, top[-1], top[0], top[1]);
+uint32_t VP8LPredictor10_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top) {
+  const uint32_t pred = Average4(*left, top[-1], top[0], top[1]);  // backward
   return pred;
 }
-uint32_t VP8LPredictor11_C(const uint32_t* const left,
-                           const uint32_t* const top) {
-  const uint32_t pred = Select(top[0], *left, top[-1]);
+uint32_t VP8LPredictor11_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top) {
+  const uint32_t pred = Select(top[0], *left, top[-1]);  // backward access
   return pred;
 }
-uint32_t VP8LPredictor12_C(const uint32_t* const left,
-                           const uint32_t* const top) {
+uint32_t VP8LPredictor12_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   const uint32_t pred = ClampedAddSubtractFull(*left, top[0], top[-1]);
   return pred;
 }
-uint32_t VP8LPredictor13_C(const uint32_t* const left,
-                           const uint32_t* const top) {
+uint32_t VP8LPredictor13_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top) {
   const uint32_t pred = ClampedAddSubtractHalf(*left, top[0], top[-1]);
   return pred;
 }
 
-static void PredictorAdd0_C(const uint32_t* in, const uint32_t* upper,
-                            int num_pixels, uint32_t* WEBP_RESTRICT out) {
+// 'out' requires WEBP_BIDI_INDEXABLE: PredictorAdd1_C reads out[-1] as the
+// left-neighbor pixel. 'upper' requires WEBP_BIDI_INDEXABLE: GENERATE_PREDICTOR_ADD
+// passes 'upper + x' to predictors that may access top[-1].
+static void PredictorAdd0_C(const uint32_t* WEBP_BIDI_INDEXABLE in,
+                            const uint32_t* WEBP_BIDI_INDEXABLE upper,
+                            int num_pixels,
+                            uint32_t* WEBP_RESTRICT WEBP_BIDI_INDEXABLE out) {
   int x;
   (void)upper;
   for (x = 0; x < num_pixels; ++x) out[x] = VP8LAddPixels(in[x], ARGB_BLACK);
 }
-static void PredictorAdd1_C(const uint32_t* in, const uint32_t* upper,
-                            int num_pixels, uint32_t* WEBP_RESTRICT out) {
+static void PredictorAdd1_C(const uint32_t* WEBP_BIDI_INDEXABLE in,
+                            const uint32_t* WEBP_BIDI_INDEXABLE upper,
+                            int num_pixels,
+                            uint32_t* WEBP_RESTRICT WEBP_BIDI_INDEXABLE out) {
   int i;
-  uint32_t left = out[-1];
+  uint32_t left = out[-1];  // Backward access: requires WEBP_BIDI_INDEXABLE
   (void)upper;
   for (i = 0; i < num_pixels; ++i) {
     out[i] = left = VP8LAddPixels(in[i], left);
@@ -262,8 +274,9 @@ static void PredictorInverseTransform_C(const VP8LTransform* const transform,
 
 // Add green to blue and red channels (i.e. perform the inverse transform of
 // 'subtract green').
-void VP8LAddGreenToBlueAndRed_C(const uint32_t* src, int num_pixels,
-                                uint32_t* dst) {
+void VP8LAddGreenToBlueAndRed_C(const uint32_t* WEBP_BIDI_INDEXABLE src,
+                                int num_pixels,
+                                uint32_t* WEBP_BIDI_INDEXABLE dst) {
   int i;
   for (i = 0; i < num_pixels; ++i) {
     const uint32_t argb = src[i];
@@ -287,8 +300,9 @@ static WEBP_INLINE void ColorCodeToMultipliers(uint32_t color_code,
 }
 
 void VP8LTransformColorInverse_C(const VP8LMultipliers* const m,
-                                 const uint32_t* src, int num_pixels,
-                                 uint32_t* dst) {
+                                 const uint32_t* WEBP_BIDI_INDEXABLE src,
+                                 int num_pixels,
+                                 uint32_t* WEBP_BIDI_INDEXABLE dst) {
   int i;
   for (i = 0; i < num_pixels; ++i) {
     const uint32_t argb = src[i];

--- a/src/dsp/lossless.h
+++ b/src/dsp/lossless.h
@@ -16,6 +16,7 @@
 #define WEBP_DSP_LOSSLESS_H_
 
 #include "src/dsp/dsp.h"
+#include "src/utils/bounds_safety.h"
 #include "src/webp/decode.h"
 #include "src/webp/types.h"
 
@@ -28,45 +29,50 @@ extern "C" {
 //------------------------------------------------------------------------------
 // Decoding
 
-typedef uint32_t (*VP8LPredictorFunc)(const uint32_t* const left,
-                                      const uint32_t* const top);
+// VP8LPredictorFunc: 'left' is always single-dereferenced (*left only);
+// 'top' may be accessed bidirectionally (e.g. top[-1], top[0], top[1]).
+typedef uint32_t (*VP8LPredictorFunc)(const uint32_t* WEBP_SINGLE const left,
+                                      const uint32_t* WEBP_BIDI_INDEXABLE const top);
 extern VP8LPredictorFunc VP8LPredictors[16];
 
-uint32_t VP8LPredictor2_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor3_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor4_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor5_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor6_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor7_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor8_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor9_C(const uint32_t* const left,
-                          const uint32_t* const top);
-uint32_t VP8LPredictor10_C(const uint32_t* const left,
-                           const uint32_t* const top);
-uint32_t VP8LPredictor11_C(const uint32_t* const left,
-                           const uint32_t* const top);
-uint32_t VP8LPredictor12_C(const uint32_t* const left,
-                           const uint32_t* const top);
-uint32_t VP8LPredictor13_C(const uint32_t* const left,
-                           const uint32_t* const top);
+uint32_t VP8LPredictor2_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor3_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor4_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor5_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor6_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor7_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor8_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor9_C(const uint32_t* WEBP_SINGLE const left,
+                          const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor10_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor11_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor12_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top);
+uint32_t VP8LPredictor13_C(const uint32_t* WEBP_SINGLE const left,
+                           const uint32_t* WEBP_BIDI_INDEXABLE const top);
 
-// These Add/Sub function expects upper[-1] and out[-1] to be readable.
-typedef void (*VP8LPredictorAddSubFunc)(const uint32_t* in,
-                                        const uint32_t* upper, int num_pixels,
-                                        uint32_t* WEBP_RESTRICT out);
+// These Add/Sub functions expect upper[-1] and out[-1] to be readable.
+// Hence upper and out require WEBP_BIDI_INDEXABLE (bidirectional indexing).
+typedef void (*VP8LPredictorAddSubFunc)(const uint32_t* WEBP_BIDI_INDEXABLE in,
+                                        const uint32_t* WEBP_BIDI_INDEXABLE upper,
+                                        int num_pixels,
+                                        uint32_t* WEBP_RESTRICT WEBP_BIDI_INDEXABLE out);
 extern VP8LPredictorAddSubFunc VP8LPredictorsAdd[16];
 extern VP8LPredictorAddSubFunc VP8LPredictorsAdd_C[16];
 extern VP8LPredictorAddSubFunc VP8LPredictorsAdd_SSE[16];
 
-typedef void (*VP8LProcessDecBlueAndRedFunc)(const uint32_t* src,
-                                             int num_pixels, uint32_t* dst);
+typedef void (*VP8LProcessDecBlueAndRedFunc)(
+    const uint32_t* WEBP_BIDI_INDEXABLE src, int num_pixels,
+    uint32_t* WEBP_BIDI_INDEXABLE dst);
 extern VP8LProcessDecBlueAndRedFunc VP8LAddGreenToBlueAndRed;
 extern VP8LProcessDecBlueAndRedFunc VP8LAddGreenToBlueAndRed_SSE;
 
@@ -127,8 +133,9 @@ void VP8LColorIndexInverseTransformAlpha(
 
 // Expose some C-only fallback functions
 void VP8LTransformColorInverse_C(const VP8LMultipliers* const m,
-                                 const uint32_t* src, int num_pixels,
-                                 uint32_t* dst);
+                                 const uint32_t* WEBP_BIDI_INDEXABLE src,
+                                 int num_pixels,
+                                 uint32_t* WEBP_BIDI_INDEXABLE dst);
 
 void VP8LConvertBGRAToRGB_C(const uint32_t* WEBP_RESTRICT src, int num_pixels,
                             uint8_t* WEBP_RESTRICT dst);
@@ -140,8 +147,9 @@ void VP8LConvertBGRAToRGB565_C(const uint32_t* WEBP_RESTRICT src,
                                int num_pixels, uint8_t* WEBP_RESTRICT dst);
 void VP8LConvertBGRAToBGR_C(const uint32_t* WEBP_RESTRICT src, int num_pixels,
                             uint8_t* WEBP_RESTRICT dst);
-void VP8LAddGreenToBlueAndRed_C(const uint32_t* src, int num_pixels,
-                                uint32_t* dst);
+void VP8LAddGreenToBlueAndRed_C(const uint32_t* WEBP_BIDI_INDEXABLE src,
+                                int num_pixels,
+                                uint32_t* WEBP_BIDI_INDEXABLE dst);
 
 // Must be called before calling any of the above methods.
 void VP8LDspInit(void);


### PR DESCRIPTION
This patch begins extending the -fbounds-safety annotations to src/dsp/lossless.c, following the pattern already established in src/dec/ and using the macro infrastructure in src/utils/bounds_safety.h.

## Background
The -fbounds-safety adoption in libwebp started with src/dec/, where pointers are progressively being annotated with WEBP_SINGLE,WEBP_INDEXABLE, and WEBP_BIDI_INDEXABLE to make memory access semantics explicit and machine-verifiable. The src/dsp/ subsystem currently has no coverage under this model. This matters because dsp/ functions sit
directly on the pixel-processing hot path for VP8L lossless decoding they receive raw pointers derived from untrusted file data and are called in tight loops over image rows.

## What this patch addresses
The first issue is the use of negative pointer offsets in seven VP8LPredictor*_C functions. Predictors 4, 6, 8, 10, 11, 12, and 13 all access top[-1], which refers to the pixel immediately to the left of the current position on the previous row. This access pattern is correct and intentional: these functions are never called when x == 0, so top[-1] is always within the allocated row buffer. The problem is that this invariant is entirely implicit. The function signatures declare top as a plain `const uint32_t*`, which gives the compiler and any bounds-checking toolchain no information about the valid access range. If a future change in the calling code in PredictorInverseTransform_C or
GENERATE_PREDICTOR_ADD were to violate the x > 0 precondition, the resulting out-of-bounds read would be silent and undetectable.

Marking top as WEBP_BIDI_INDEXABLE converts this implicit assumption into an explicit, verifiable constraint. When compiled with-DWEBP_SUPPORT_FBOUNDS_SAFETY on Apple Clang or a compatible toolchain, the runtime will trap any access outside the annotated bounds before it can produce memory corruption.

The left parameter is a simpler case: it is always accessed only as *left (a single dereference), never as left[n] for any n. WEBP_SINGLE makes this precise.

The second issue is in PredictorAdd1_C. This function reads out[-1] before the loop begins, to initialize the running left-neighbor value for delta decoding. The header comment in lossless.h has always documented this precondition explicitly:
  "These Add/Sub functions expect upper[-1] and out[-1] to be readable."
But that comment has no enforcement mechanism. With WEBP_BIDI_INDEXABLE on out and upper, the type system now carries the same information that the comment carries, and the toolchain can verify it.

VP8LAddGreenToBlueAndRed_C and VP8LTransformColorInverse_C are annotated with WEBP_BIDI_INDEXABLE on src and dst. Both functions iterate over num_pixels elements using index-based access, and the annotation correctly describes the valid access range relative to the pointer.

## Changes in detail
In src/dsp/lossless.h:
- Added #include "src/utils/bounds_safety.h"
- Updated VP8LPredictorFunc typedef: left takes WEBP_SINGLE, top takes
  WEBP_BIDI_INDEXABLE
- Updated VP8LPredictorAddSubFunc typedef: in, upper, and out all take
  WEBP_BIDI_INDEXABLE (upper and out due to documented [-1] access;
  in is bidi-annotated for consistency since it is passed offset into
  the predictor as upper+x)
- Updated VP8LProcessDecBlueAndRedFunc typedef: src and dst take
  WEBP_BIDI_INDEXABLE
- Updated all twelve VP8LPredictor*_C declarations to match

In src/dsp/lossless.c:
- Added #include "src/utils/bounds_safety.h"
- Added a block comment before VP8LPredictor0_C explaining the annotation
  rationale for the entire predictor group
- All fourteen VP8LPredictor*_C implementations updated; added inline
  comments on the specific lines performing top[-1] access to make the
  reason for WEBP_BIDI_INDEXABLE self-evident during code review
- PredictorAdd0_C and PredictorAdd1_C updated; inline comment on the
  out[-1] read in Add1 explains why bidi access is needed
- VP8LAddGreenToBlueAndRed_C and VP8LTransformColorInverse_C updated

## Testing
The patch was built with the existing GCC-based CMake configuration (the build_asan/ target). All files compiled without warnings or errors. The annotations are zero-overhead no-ops in this configuration — they only activate when the code is compiled with -DWEBP_SUPPORT_FBOUNDS_SAFETY on a toolchain that supports __ptrcheck_abi extensions (Apple Clang with -fbounds-safety, or compatible).
No logic was changed. This is purely a type-level annotation patch.

## Scope and follow-up
This PR covers src/dsp/lossless.c and its header. The SIMD specializations (lossless_sse2.c, lossless_sse41.c, lossless_avx2.c, lossless_neon.c) define their own versions of the PredictorAdd functions and will need matching annotations in follow-up work. The same applies to lossless_enc.c and the remaining files in src/dsp/.
